### PR TITLE
Add key delegation feature

### DIFF
--- a/packages/client/src/Bubble.js
+++ b/packages/client/src/Bubble.js
@@ -549,7 +549,8 @@ export class RPCFactory {
     return this.signFunction(Web3.utils.keccak256(JSON.stringify(rpc)).slice(2))
       .then(signature => {
         if (typeof signature === 'object') {
-          rpc.params.signaturePrefix = signature.prefix;
+          if (signature.prefix) rpc.params.signaturePrefix = signature.prefix;
+          if (signature.delegate) rpc.params.delegate = signature.delegate;
           rpc.params.signature = signature.signature;
         }
         else rpc.params.signature = signature;

--- a/packages/client/src/Delegation.js
+++ b/packages/client/src/Delegation.js
@@ -1,0 +1,88 @@
+// Copyright (c) 2023 Bubble Protocol
+// Distributed under the MIT software license, see the accompanying
+// file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+import { Delegation as CoreDelegation, assert } from '@bubble-protocol/core';
+import Web3 from 'web3';
+
+export class Delegation extends CoreDelegation {
+
+  /**
+   * Permit a delegated key to access a bubble on behalf of a signer.
+   * 
+   * @param {Address} delegate the address to delegate to
+   * @param {Number|String} expires the UNIX expiry time (in seconds) or the string 'never'
+   */
+  constructor(delegate, expires) {
+    super(delegate, expires);
+  }
+
+  /**
+   * Permits this delegate to access the given off-chain bubble. If the provider is not given
+   * as part of the id, permission will be granted regardless of where the bubble is hosted.
+   * If present, it will only be granted if hosted by that specific provider.
+   * 
+   * @param {ContentId|Object} bubbleId the bubble's content id or an object containing at least
+   * chain and contract.
+   */
+  permitAccessToBubble(bubbleId) {
+    assert.isObject(bubbleId, 'bubbleId');
+    if (bubbleId.provider) this._addPermission(new CoreDelegation.BubblePermission(bubbleId));
+    else this._addPermission(new CoreDelegation.ContractPermission(bubbleId));
+  }
+
+
+  /**
+   * Permits the delegate to access all bubbles accessible by the signer.
+   * 
+   * WARNING: The delegate key will have the same access rights as the signing key.  This includes
+   * all existing bubbles anywhere, and any bubbles created in the future.  Ensure the delegate 
+   * private key is as secure as the signing key.
+   */
+  permitAccessToAllBubbles() {
+    this.permissions = 'all-permissions';
+  }
+
+
+  /**
+   * Signs this delegation object.
+   * 
+   * @param {Function} signFunction function that signs the delegation packet. Signing this
+   * delegation will permit the delegator to act as the signer under the permissions set. 
+   * 
+   * Takes the form:
+   * 
+   *   (Buffer: hash) => { return Promise to resolve the signature of the hash as a Buffer }
+   * 
+   * The type and format of the signature must be appropriate to the blockchain platform.
+   *
+   * @returns this object
+   */
+  async sign(signFunction) {
+    const packet = {
+      delegate: this.delegate,
+      expires: this.expires,
+      permissions: this.permissions
+    }
+    const signature = await signFunction(Web3.utils.keccak256(JSON.stringify(packet)).slice(2))
+    if (typeof signature === 'object') {
+      if (signature.prefix) this.signaturePrefix = signature.prefix;
+      this.signature = signature.signature;
+    }
+    else this.signature = signature;
+    return this;
+  }
+    
+
+  /**
+   * Adds a permission to the list of permissions to grant to this delegate.
+   * 
+   * @param {Permission} permission the permission to add to the list of permissions
+   */
+  _addPermission(permission) {
+    if (!assert.isArray(this.permissions)) this.permissions = [];
+    this.permissions.push(permission);
+  }
+
+}
+

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -9,4 +9,6 @@ export {PublicContentManager} from './PublicContentManager.js';
 export {EncryptionPolicy} from './EncryptionPolicy.js';
 export {bubbleProviders} from './bubble-providers/index.js';
 export {encryptionPolicies} from './encryption-policies/index.js';
+export {Delegation} from './Delegation.js';
+export * from '@bubble-protocol/core';
 export * from './utils.js';

--- a/packages/client/src/utils.js
+++ b/packages/client/src/utils.js
@@ -24,13 +24,16 @@ const file0 = "0000000000000000000000000000000000000000000000000000000000000000"
  * recovering the signatory from a signed request.
  * 
  * @param {string} sig signature
+ * @param {Delegation} delegate optional delegate to include in the signature
  * @returns signature object
  */
-export function toEthereumSignature(sig) {
-  return {
+export function toEthereumSignature(sig, delegate) {
+  const result = {
     prefix: "\x19Ethereum Signed Message:\n64",
-    signature: sig
-  }
+    signature: sig,
+  };
+  if (delegate) result.delegate = delegate;
+  return result;
 }
 
 
@@ -39,10 +42,11 @@ export function toEthereumSignature(sig) {
  * (@see `toEthereumSignature`).
  * 
  * @param {function} signFunction sign function whose signature must be converted
+ * @param {Delegation} delegate optional delegate to include in the signature
  * @returns the same signFunction
  */
-export function toEthereumSignFunction(signFunction) {
-  return (hash) => signFunction(hash).then(toEthereumSignature);
+export function toEthereumSignFunction(signFunction, delegate) {
+  return (hash) => signFunction(hash).then(sig => toEthereumSignature(sig, delegate));
 }
 
 

--- a/packages/core/src/BlockchainProvider.js
+++ b/packages/core/src/BlockchainProvider.js
@@ -13,14 +13,24 @@ export class BlockchainProvider {
   /**
    * Calls the getPermissions function of the given contract and returns the permission bits.
    * 
-   * @param {20-byte hex string} contract address of the contract
-   * @param {20-byte hex string} account address to pass to the contract's getPermissions function
-   * @param {32-byte hex string} file bytes32 (as hex string) to pass to the contract's 
+   * @param {hex string} contract address of the contract
+   * @param {hex string} account address to pass to the contract's getPermissions function
+   * @param {hex string} file bytes32 (as hex string) to pass to the contract's 
    * getPermissions function
    * @returns Promise to return a BigInt containing the 256-bit uint returned by the contract
    */
   getPermissions(contract, account, file) {
     throw new Error('BlockchainProvider.getPermissions is a virtual function and must be implemented');
+  }
+
+  /**
+   * Calls the blockchain's delegate revocation contract to check if the given hash has been 
+   * revoked.
+   * 
+   * @param {32-byte hex string} delegateHash the hash to check if revoked
+   */
+  hasBeenRevoked(delegateHash) {
+    throw new Error('BlockchainProvider.hasBeenRevoked is a virtual function and must be implemented');
   }
 
   /**

--- a/packages/core/src/Delegation.js
+++ b/packages/core/src/Delegation.js
@@ -1,0 +1,141 @@
+// Copyright (c) 2023 Bubble Protocol
+// Distributed under the MIT software license, see the accompanying
+// file LICENSE or http://www.opensource.org/licenses/mit-license.php.
+
+/**
+ * Delegations allow a wallet to permit a different private key to act on it's behalf when 
+ * accessing a bubble.
+ * 
+ * Delegation format with example permissions:
+ *
+ * {
+ *   delegate: '<address>',
+ *   expires: '<expiry_unix_time>',
+ *   permissions: [
+ *     {type: 'contract', chain: 1, contract: '<contract-address>'}
+ *     {type: 'bubble', chain: 1, contract: '<contract-address>', provider: 'provider'}
+ *   ],
+ *   signaturePrefix: '...',
+ *   signature: '...'
+ * }
+ * 
+ */
+
+
+import * as assert from './assertions.js';
+
+
+//
+// Permissions
+//
+
+class Permission {
+
+  constructor(type, fields={}) {
+    assert.isString(type, 'type');
+    assert.isObject(fields, 'fields');
+    this.type = type;
+    Object.assign(this, fields);
+  }
+
+  isPermitted() {
+    throw new Error('Permission.isPermitted is a virtual function and has not been implemented');
+  }
+  
+}
+
+
+class BubblePermission extends Permission {
+
+  constructor(bubbleId) {
+    assert.isObject(bubbleId, 'bubbleId');
+    assert.isNumber(bubbleId.chain, 'chain');
+    assert.isHexString(bubbleId.contract, 'contract');
+    assert.isString(bubbleId.provider, 'provider');
+    super('bubble', bubbleId);
+  }
+  
+  isPermitted(contentId) {
+    return this.chain === contentId.chain && this.contract.toLowerCase() === contentId.contract.toLowerCase() && this.provider === contentId.provider
+  }
+
+}
+
+
+class ContractPermission extends Permission {
+
+  constructor(bubbleId) {
+    assert.isNumber(bubbleId.chain, 'chain');
+    assert.isHexString(bubbleId.contract, 'contract');
+    super('contract', {chain: bubbleId.chain, contract: bubbleId.contract});
+  }
+
+  isPermitted(contentId) {
+    return this.chain === contentId.chain && this.contract.toLowerCase() === contentId.contract.toLowerCase();
+  }
+  
+}
+
+
+class PermissionFactory {
+
+  parse(obj) {
+    assert.isObject(obj, 'obj');
+    assert.isString(obj.type, 'type');
+    switch (obj.type) {
+      case 'contract': return new ContractPermission(obj);
+      case 'bubble': return new BubblePermission(obj);
+      default: throw new Error(`invalid permission type '${obj.type}'`);
+    }
+  }
+
+}
+
+
+//
+// Delegation class
+//
+
+export class Delegation {
+
+  static PermissionFactory = new PermissionFactory();
+  static ContractPermission = ContractPermission;
+  static BubblePermission = BubblePermission;
+
+  /**
+   * The address to delegate to
+   */
+  delegate;
+
+  /**
+   * The expiry time (seconds since 1-Jan-1970)
+   */
+  expires;
+
+  /**
+   * List of permissions for which this delegate is permitted to act as the signer
+   */
+  permissions;
+
+
+  /**
+   * 
+   * @param {Address} delegate the address to delegate to
+   * @param {Number|String} expires the UNIX expiry time (in seconds) or the string 'never'
+   * @param {Array|String} permissions list of Permission objects or the string 'all-permissions'
+   */
+  constructor(delegate, expires, permissions) {
+    assert.isHexString(delegate, 'delegate');
+    if (expires !== 'never') assert.isNumber(expires, 'expires');
+    if (permissions === undefined) permissions = [];
+    if (permissions !== 'all-permissions') {
+      assert.isArray(permissions, 'permissions');
+      if (!permissions.every(p => assert.isInstanceOf(p, Permission))) throw new Error('invalid permission');
+    }
+    this.delegate = delegate;
+    this.expires = expires;
+    this.permissions = permissions;
+  }
+
+}
+

--- a/packages/core/src/blockchain-providers/Web3Provider.js
+++ b/packages/core/src/blockchain-providers/Web3Provider.js
@@ -33,6 +33,9 @@ export class Web3Provider extends BlockchainProvider {
       })
   }
 
+  hasBeenRevoked() {
+    return false;  // revocation service not yet available
+  }
 
   getChainId() {
     return this.chainId;

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -15,3 +15,4 @@ export {ROOT_PATH} from './constants.js';
 export * as assert from './assertions.js';
 export {BubbleError, ErrorCodes} from './errors.js';
 export {blockchainProviders} from './blockchain-providers/index.js';
+export {Delegation} from './Delegation.js';

--- a/packages/server/src/Delegation.js
+++ b/packages/server/src/Delegation.js
@@ -1,0 +1,126 @@
+import { Delegation as CoreDelegation, assert } from '@bubble-protocol/core';
+import Web3 from 'web3';
+
+/**
+ * Server-side function to parse and validate a received signatory delegation object.
+ * 
+ * @param {Object} delegation signed delegation object to parse and validate
+ * @param {BlockchainProvider} blockchainProvider provider to allow signature to be recovered
+ * @returns ServerDelegation object that can be queried
+ */
+export async function parseDelegation(delegation, blockchainProvider) {
+  const packet = {...delegation};
+  delete packet.signature;
+  delete packet.signaturePrefix;
+  try {
+    assert.isHexString(delegation.signature, 'signature');
+    if (delegation.signaturePrefix) assert.isString(delegation.signaturePrefix, 'signaturePrefix');
+    const hash = Web3.utils.keccak256(JSON.stringify(packet)).slice(2);
+    if (delegation.signaturePrefix) hash = Web3.utils.keccak256(delegation.signaturePrefix+hash).slice(2);
+    const signatory = await blockchainProvider.recoverSignatory(hash, delegation.signature);
+    return new Delegation(delegation, hash, signatory);
+  }
+  catch(error) {
+    return new Delegation(delegation, undefined, undefined, error);
+  }
+}
+
+
+class Delegation extends CoreDelegation {
+
+  /**
+   * The unique hash of the delegation
+   */
+  hash;
+
+  /**
+   * The signer of this delegation
+   */
+  signatory;
+
+  /**
+   * 
+   * @param {Object} delegation The original signed delegation object
+   * @param {Hash} hash The hash of the delegation packet (the hash signed by the signatory)
+   * @param {Address} signatory The signer's address
+   * @param {Error} signError Optional error.  This delegation will be marked invalid if present
+   */
+  constructor(delegation, hash, signatory, signError) {
+    try{
+      assert.isObject(delegation, 'delegation');
+      if (hash) assert.isHex32(hash, 'hash');
+      if (signatory) assert.isHexString(signatory, 'signatory');
+      assert.isNotNull(delegation.permissions, 'permissions');
+      let permissions = delegation.permissions;
+      if (assert.isArray(permissions)) {
+        permissions = delegation.permissions.map(p => CoreDelegation.PermissionFactory.parse(p));
+      }
+      super(delegation.delegate, delegation.expires, permissions);
+      this.hash = hash;
+      this.signatory = signatory;
+      this.error = signError;
+      this.valid = signError === undefined;
+    }
+    catch(error) {
+      super('0x00', 0, []);
+      this.error = error;
+      this.valid = false;
+    }
+  }
+
+  /**
+   * Tests if the given user has been delegated the permission to act access the given content.
+   * 
+   * @param {Address} user public address of user 
+   * @param {ContentId} contentId id of the content being accessed
+   * @returns true if the user has permission
+   */
+  canAccessContent(user, contentId) {
+    return this.isRelevant() &&
+      this.hasDelegate(user) &&
+      ( this.permissions === 'all-permissions' ||
+        this.permissions.some(r => r.isPermitted(contentId)) );
+  }
+
+  /**
+   * A delegation is invalid if it is malformed or the signature is invalid.
+   * 
+   * @returns true if valid
+   */
+  isValid() {
+    return this.valid;
+  }
+
+  /**
+   * A delegation is relevant if it is valid and hasn't expired.
+   * 
+   * @returns true if valid and hasn't expired
+   */
+  isRelevant() {
+    return this.valid && !this.hasExpired();
+  }
+
+  /**
+   * A delegation has expired if now is beyond its `expires` time.  Always check the delegation
+   * is valid before using this method.
+   * 
+   * @returns true if expired 
+   */
+  hasExpired() {
+    return this.expires !== 'never' && this.expires < (Date.now() / 1000);
+  }
+
+  /**
+   * Check if the given delegate is the subject of this delegation.
+   * 
+   * @param {Address} delegate public address of the delegate to check
+   * @returns true if the delegation includes the given delegate
+   */
+  hasDelegate(delegate) {
+    return delegate.toLowerCase() === this.delegate.toLowerCase()
+  }
+
+
+}
+
+

--- a/packages/server/test/Guardian/common.js
+++ b/packages/server/test/Guardian/common.js
@@ -83,8 +83,16 @@ export function signRPC(method, params, key, prefix='') {
   }
   return crypto.subtle.sign(ECDSA_PARAMS, key.privateKey, Buffer.from(prefix+JSON.stringify(packet)))
     .then(signature => {
-      packet.params.signature = uint8ArrayToHex(signature);
-      if (prefix !== '') packet.params.signaturePrefix = prefix;
+      params.signature = uint8ArrayToHex(signature);
+      if (prefix !== '') params.signaturePrefix = prefix;
+    })
+}
+
+export function signDelegate(delegate, key, prefix='') {
+  return crypto.subtle.sign(ECDSA_PARAMS, key.privateKey, Buffer.from(prefix+JSON.stringify(delegate)))
+    .then(signature => {
+      delegate.signature = uint8ArrayToHex(signature);
+      if (prefix !== '') delegate.signaturePrefix = prefix;
     })
 }
 
@@ -94,6 +102,12 @@ export function hashRPC(method, params, prefix='') {
     params: params
   } 
   const hash = Web3.utils.sha3(JSON.stringify(packet)).slice(2);
+  if (prefix !== '') return Web3.utils.sha3(prefix+hash).slice(2)
+  else return hash;
+}
+
+export function hashDelegate(delegate, prefix='') {
+  const hash = Web3.utils.sha3(JSON.stringify(delegate)).slice(2);
   if (prefix !== '') return Web3.utils.sha3(prefix+hash).slice(2)
   else return hash;
 }
@@ -145,6 +159,7 @@ export class TestBlockchainProvider extends BlockchainProvider {
     this.getPermissions = jest.fn(() => Promise.reject(new Error('unexpected stub call: getPermissions')));
     this.getChainId = jest.fn(() => { throw new Error('unexpected stub call: getChainId') });
     this.recoverSignatory = jest.fn(() => Promise.reject(new Error('unexpected stub call: recoverSignature')));
+    this.hasBeenRevoked = jest.fn(() => Promise.reject(new Error('unexpected stub call: hasBeenRevoked')));
   }
 
 }

--- a/packages/server/test/Guardian/post.params.js
+++ b/packages/server/test/Guardian/post.params.js
@@ -21,7 +21,7 @@ export function testPostParams() {
     key2.address = await publicKeyToEthereumAddress(key2.publicKey);
     dataServer = new TestDataServer();
     blockchainProvider = new TestBlockchainProvider();
-    guardian = new Guardian(dataServer, blockchainProvider);
+    guardian = new Guardian(dataServer, blockchainProvider, '');
   })
 
   beforeEach( () => {
@@ -277,6 +277,17 @@ export function testPostParams() {
       params.signaturePrefix = {};
       await signRPC('write', params, key1);
       return expect(guardian.post('write', params)).rejects.toBeBubbleError(new BubbleError(ErrorCodes.JSON_RPC_ERROR_INVALID_METHOD_PARAMS, 'malformed signaturePrefix'));
+    });
+
+  })
+
+  describe("delegate", () => {
+
+    test("is not an object", async () => {
+      const params = {...VALID_RPC_PARAMS};
+      params.delegate = "a delegate";
+      await signRPC('write', params, key1);
+      return expect(guardian.post('write', params)).rejects.toBeBubbleError(new BubbleError(ErrorCodes.JSON_RPC_ERROR_INVALID_METHOD_PARAMS, 'malformed delegate'));
     });
 
   })

--- a/test/code-examples/server.test.js
+++ b/test/code-examples/server.test.js
@@ -94,7 +94,7 @@ describe('Server README code examples', () => {
 
       // Construct the Bubble Guardian and launch the server
       const dataServer = new MyDataServer();
-      const guardian = new Guardian(dataServer, blockchainProvider);
+      const guardian = new Guardian(dataServer, blockchainProvider, 'http://127.0.0.1:'+SERVER_PORT);
       const bubbleServer = new BubbleServer(SERVER_PORT, guardian);
 
       // Launch the server

--- a/test/mockups/RamBasedBubbleServer.js
+++ b/test/mockups/RamBasedBubbleServer.js
@@ -7,10 +7,10 @@ import {Guardian} from '../../packages/server';
 
 export class RamBasedBubbleServer {
 
-  constructor(port, blockchainProvider) {
+  constructor(host, port, blockchainProvider) {
     this.port = port;
     this.dataServer = new RamBasedDataServer();
-    this.guardian = new Guardian(this.dataServer, blockchainProvider);
+    this.guardian = new Guardian(this.dataServer, blockchainProvider, host+':'+port);
     const guardian = this.guardian;
 
     function post(method, params, callback) {

--- a/test/mockups/test-servers.js
+++ b/test/mockups/test-servers.js
@@ -41,7 +41,7 @@ export async function startServers(options={}) {
   }
   blockchainProvider = new blockchainProviders.Web3Provider(CHAIN_ID, new Web3(BLOCKCHAIN_SERVER_URL), CONTRACT_ABI_VERSION, web3ProviderOpts);
   if(!options.noBubbleServer) {
-    bubbleServer = new RamBasedBubbleServer(8131, blockchainProvider);
+    bubbleServer = new RamBasedBubbleServer('http://127.0.0.1', 8131, blockchainProvider);
     dataServer = bubbleServer.dataServer;
     await bubbleServer.start();
   }


### PR DESCRIPTION
Adds a Delegation class to the client for users to construct key delegations.  See the client README for details.

The Guardian will process RPC packets containing a 'delegate' field and will override the RPC signatory with the delegate address, provided the delegation is valid, has not expired and contains permission for the requested bubble.

This is a breaking change for server implementations, which will need to construct the Guardian with a third parameter - the url of server api for comparing with the provider field within the delegation permissions.

Limitations:
- No revoke feature.  Revoking delegates is not yet supported.  Consideration needs to be given to only allow the signer to revoke it's delegations.